### PR TITLE
[webpack v5] Error: Universal Chunk Loading is not implemented yet

### DIFF
--- a/packages/emp-cli/webpack/config/common.js
+++ b/packages/emp-cli/webpack/config/common.js
@@ -59,7 +59,10 @@ module.exports = (env, config, args, {isRemoteConfig, remoteConfig}) => {
       // experiments.outputModule 为 true.
       // module: true,
       // libraryTarget: 'module',
-      //
+
+      // https://github.com/webpack/webpack/issues/11660
+      chunkLoading: false,
+      wasmLoading: false
     },
     resolve: {
       modules: [


### PR DESCRIPTION
[!11660](https://github.com/webpack/webpack/issues/11660)

不修改该设置将会出现如标题的错误