### PR TITLE
Feature jeremy workspacecli

### DIFF
--- a/packages/emp-cli/README-zh_CN.md
+++ b/packages/emp-cli/README-zh_CN.md
@@ -88,3 +88,50 @@
 }
 
 ```
+
+
+# 声明文件同步方案与多版本
+
+## 前置条件:
++ 使用 `@efox/emp-cli` `1.8.6` 及以上版本
++ `tsconfig.json` `include`配置项请添加 `types` 目录
+```json
+"include": [
+    "types"
+]
+```
++ `package.json`指令强化
+```json
+"dev": "emp workspace -t pullTypes && emp dev",
+"tsc": "emp tsc -w && emp workspace -t pushTypes",
+```
+## 使用方式:
+### 初始化本地emp工作区配置文件
+
+命令行使用 `emp workspace -t init` 指令，会在当前工作目录根目录创建`emp.workspace.config.ts`配置文件，并会在当前目录 `.gitignore`添加`types/`与 `emp.workspace.config.ts`忽略，如项目已有上述文件，请重命名为其他文件，并在之前使用`git rm [filename]` 移除并`push`到远端
+
+配置文件内容参考如下:
+```javascript
+import {IWorkSpaceConfig} from '@efox/emp-cli/types/emp-workspace-config'
+
+const empWorkspaceConfig: IWorkSpaceConfig = {
+    // 执行 emp workspace -t pullTypes 指令，会把 pullConfig配置的远程声明文件，拉到当前根目录 types目录下
+  pullConfig: {
+    pcbase: 'http://res-pc-bc-dev.rshun.net/emp_base/1.0.0/index.d.ts',
+    chatbox: 'http://res-pc-bc.rshun.net/emp_chatbox/index.d.ts',
+    stream: 'https://pcyy-base-component.yy.com/bdgamelive/streamer_1.0.10/index.d.ts',
+    localTypeTest1: 'E:/baidu/git/bdgamelive/src/types/svga.d.ts',
+    localTypeTest2: 'E:/baidu/git/bdgamelive/src/types/empbdgamechatbox.d.ts',
+  },
+  // 执行 emp workspace -t pushTypes 指令，会把 pushConfig配置的本地声明文件，推送到remotePath所在的目录
+  pushConfig: {
+    localPath: './dist/index.d.ts',
+    remotePath: ['E:/baidu/git/test/zzz.d.ts', 'G:/baidu/git/test/zzz.d.ts'],
+  },
+}
+export default empWorkspaceConfig
+```
+
+## 声明文件添加版本标识
+
+使用`emp tsc -w`指令生成的声明文件，将会把`主要版本号`,`次要版本号`拼接到模块项目名中

--- a/packages/emp-cli/bin/emp.js
+++ b/packages/emp-cli/bin/emp.js
@@ -113,11 +113,11 @@ program
   .command('ts:create')
   .alias('tsc')
   .description('ts类型创建')
+  .option('-w, --withVersion')
   .option('-n, --createName <createName>', '文件名 默认为 index.d.ts [* 使用默认值更方便同步]')
   .option('-p, --createPath <createPath>', '相对命令行目录 默认为 dist')
-  //
-  .action(({createName, createPath}) => {
-    require('../scripts/typescript')('create', {createName, createPath})
+  .action(({createName, createPath, withVersion}) => {
+    require('../scripts/typescript')('create', {createName, createPath, withVersion})
   })
 // ts 类型同步
 program

--- a/packages/emp-cli/bin/emp.js
+++ b/packages/emp-cli/bin/emp.js
@@ -264,5 +264,13 @@ program
     require('../scripts/dist')({ts, createName, createPath})
   })
 
+// 生成workspace本地配置
+program
+  .command('workspace:init')
+  .description('生成本地开发配置 如:声明文件同步配置')
+  .action(() => {
+    require('../scripts/workspace')()
+  })
+
 // 执行命令
 program.parse(process.argv)

--- a/packages/emp-cli/bin/emp.js
+++ b/packages/emp-cli/bin/emp.js
@@ -266,10 +266,17 @@ program
 
 // 生成workspace本地配置
 program
-  .command('workspace:init')
-  .description('生成本地开发配置 如:声明文件同步配置')
-  .action(() => {
-    require('../scripts/workspace')()
+  .command('workspace')
+  .option('-t, --type <type>')
+  .description([
+    `本地开发配置:`,
+    `[-t init]: 生成配置文件，如:声明文件同步配置`,
+    `[-t pullTypes]:根据workspace:init配置文件的内容，拉取"远程"或"本地"声明文件到本地types目录`,
+    `[-t pushTypes]: 根据workspace:init配置文件的内容，分发声明文件到"本地"远程目录`,
+  ])
+  .action(({type}) => {
+    console.log('workspace type:', type)
+    require('../scripts/workspace')(type)
   })
 
 // 执行命令

--- a/packages/emp-cli/package.json
+++ b/packages/emp-cli/package.json
@@ -35,7 +35,7 @@
     "@babel/runtime": "^7.12.5",
     "@efox/emp-react": "^1.1.3",
     "@efox/emp-tsconfig": "^1.1.3",
-    "@efox/emp-tune-dts-plugin": "^1.1.7",
+    "@efox/emp-tune-dts-plugin": "^1.1.9",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-beta.1",
     "@svgr/webpack": "^5.4.0",
     "@swc/core": "^1.2.50",

--- a/packages/emp-cli/package.json
+++ b/packages/emp-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@efox/emp-cli",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "keywords": [
     "react",
     "module federation",

--- a/packages/emp-cli/package.json
+++ b/packages/emp-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@efox/emp-cli",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "keywords": [
     "react",
     "module federation",

--- a/packages/emp-cli/scripts/typescript.js
+++ b/packages/emp-cli/scripts/typescript.js
@@ -20,7 +20,7 @@ async function download(remoteUrl, saveName, savePath) {
   })
 }
 
-module.exports = async (type, {createName, createPath, remoteUrl, saveName, savePath}) => {
+module.exports = async (type, {createName, createPath, remoteUrl, saveName, savePath, withVersion}) => {
   await setPaths({})
   switch (type) {
     case 'create':
@@ -38,6 +38,7 @@ module.exports = async (type, {createName, createPath, remoteUrl, saveName, save
           path: createPath,
           name: createName,
           isDefault: true,
+          withVersion,
         })
       } else {
         // console.error(`${createPath} not exist, please tsc after build!`)

--- a/packages/emp-cli/scripts/workspace.js
+++ b/packages/emp-cli/scripts/workspace.js
@@ -1,10 +1,11 @@
 /**
  * 生成本地开发配置
  */
-const fs = require('fs')
+const fse = require('fs-extra')
+const {tsCompile, requireFromString} = require('../helpers/compile')
 
 // todo 获取 emp.config 的配置，动态生成@fileTemplate内容
-// const {resolveApp} = require('../helpers/paths')
+const {resolveApp} = require('../helpers/paths')
 // const package = require(`${resolveApp('package.json')}`)
 const configFilePath = `emp.workspace.config.ts`
 const gitignorePath = `.gitignore`
@@ -25,29 +26,57 @@ ${configFilePath}
 types/
 `
 
-module.exports = () => {
-  fs.stat(configFilePath, (err, stats) => {
+/**
+ * 初始化 工作区开发配置， 并追加 gitignore 配置
+ */
+const init = async () => {
+  fse.stat(configFilePath, async (err, stats) => {
     if (stats) {
       console.log(`${configFilePath}已存在, 创建失败`)
     } else {
-      fs.writeFile(configFilePath, fileTemplate, err => {
-        if (err) {
-          console.log(`${configFilePath}创建失败 ${err}`)
-        } else {
-          console.log(`${configFilePath}创建成功`)
-          fs.stat(gitignorePath, (err, stats) => {
-            if (stats) {
-              fs.appendFile(gitignorePath, ignoreAppendContent, err => {
-                if (err) {
-                  console.log(`${gitignorePath}追加内容失败`)
-                } else {
-                  console.log(`${gitignorePath}追加内容成功`)
-                }
-              })
+      await fse.createFile(configFilePath)
+      const err = await fse.outputFile(configFilePath, fileTemplate)
+      if (err) {
+        console.log(`${configFilePath}创建失败 ${err}`)
+      } else {
+        console.log(`${configFilePath}创建成功`)
+        const stats = await fse.stat(gitignorePath)
+        if (stats) {
+          fse.appendFile(gitignorePath, ignoreAppendContent, err => {
+            if (err) {
+              console.log(`${gitignorePath}追加内容失败`)
+            } else {
+              console.log(`${gitignorePath}追加内容成功`)
             }
           })
         }
-      })
+      }
     }
   })
+}
+
+const pullTypes = async () => {
+  console.log('begin pullTypes')
+  const workspaceConfigPath = resolveApp(configFilePath)
+  console.log(`workspaceConfig: ${workspaceConfigPath} `)
+  fse.stat(workspaceConfigPath, async (err, stats) => {
+    if (stats) {
+      let remoteTsConfig = await fse.readFile(workspaceConfigPath, 'utf8')
+      remoteTsConfig = await tsCompile(remoteTsConfig)
+      remoteTsConfig = requireFromString(remoteTsConfig.code, '')
+      console.log('## data', remoteTsConfig)
+      console.log('## data', remoteTsConfig.default.pullConfig)
+    }
+  })
+}
+
+module.exports = type => {
+  switch (type) {
+    case 'init':
+      init()
+      break
+    case 'pullTypes':
+      pullTypes()
+      break
+  }
 }

--- a/packages/emp-cli/scripts/workspace.js
+++ b/packages/emp-cli/scripts/workspace.js
@@ -127,9 +127,18 @@ const copyLocalFile = async (path, localUrl) => {
  */
 const pushTypes = async () => {
   const remoteTsConfig = await getRemoteTsConfig()
-  console.log('remoteTsConfig.default.pushConfig.localPath', remoteTsConfig)
   if (!remoteTsConfig.default.pushConfig || remoteTsConfig.default.pushConfig.localPath.length < 1) {
     console.log('请使用 emp workspace:init 指令生成配置文件 并配置pushConfig')
+  } else {
+    const localPathPath = resolveApp(remoteTsConfig.default.pushConfig.localPath)
+    const remotePath = remoteTsConfig.default.pushConfig.remotePath
+    const isExists = await fse.pathExists(localPathPath)
+    console.log(localPathPath, `isExists:`, isExists)
+    if (remotePath && remotePath.length > 0) {
+      remotePath.forEach(item => {
+        fse.copy(localPathPath, item)
+      })
+    }
   }
 }
 

--- a/packages/emp-cli/scripts/workspace.js
+++ b/packages/emp-cli/scripts/workspace.js
@@ -12,21 +12,21 @@ const {resolveApp} = require('../helpers/paths')
 const configFilePath = `emp.workspace.config.ts`
 const gitignorePath = `.gitignore`
 const fileTemplate = `import {IWorkSpaceConfig} from '@efox/emp-cli/types/emp-workspace-config'
-
-const empWorkspaceConfig: IWorkSpaceConfig = {
-  pullConfig: {},
-  pushConfig: {
-    localPath: '',
-    remotePath: [],
-  },
-}
-export default empWorkspaceConfig
-`
+ 
+ const empWorkspaceConfig: IWorkSpaceConfig = {
+   pullConfig: {},
+   pushConfig: {
+     localPath: '',
+     remotePath: [],
+   },
+ }
+ export default empWorkspaceConfig
+ `
 
 const ignoreAppendContent = `
-${configFilePath}
-types/
-`
+ ${configFilePath}
+ types/
+ `
 
 /**
  * 初始化 工作区开发配置， 并追加 gitignore 配置
@@ -63,7 +63,6 @@ const getRemoteTsConfig = async () => {
     let remoteTsConfig = await fse.readFile(workspaceConfigPath, 'utf8')
     remoteTsConfig = await tsCompile(remoteTsConfig)
     remoteTsConfig = requireFromString(remoteTsConfig.code, '')
-    console.log('## data', remoteTsConfig)
     return remoteTsConfig
   } else {
     return null
@@ -74,6 +73,10 @@ const getRemoteTsConfig = async () => {
  * 同步远程文件
  */
 const pullTypes = async () => {
+  const isExists = await fse.pathExists(`${resolveApp('types')}`)
+  if (!isExists) {
+    await fse.mkdir(`${resolveApp('types')}`)
+  }
   const remoteTsConfig = await getRemoteTsConfig()
   if (remoteTsConfig.default.pullConfig && Object.keys(remoteTsConfig.default.pullConfig).length > 0) {
     for (let key in remoteTsConfig.default.pullConfig) {
@@ -111,13 +114,12 @@ const downloadHttpFile = async (path, remoteUrl) => {
  * @param {*} type
  */
 const copyLocalFile = async (path, localUrl) => {
-  fse.stat(localUrl, async (err, stats) => {
-    if (stats) {
-      fse.copy(localUrl, `${resolveApp('types')}/${path}.d.ts`)
-    } else {
-      console.log('本地文件不存在:', localUrl)
-    }
-  })
+  const isExists = await fse.pathExists(localUrl)
+  if (isExists) {
+    fse.copy(localUrl, `${resolveApp('types')}/${path}.d.ts`)
+  } else {
+    console.log('本地文件不存在:', localUrl)
+  }
 }
 
 /**

--- a/packages/emp-cli/scripts/workspace.js
+++ b/packages/emp-cli/scripts/workspace.js
@@ -32,59 +32,63 @@ types/
  * 初始化 工作区开发配置， 并追加 gitignore 配置
  */
 const init = async () => {
-  fse.stat(configFilePath, async (err, stats) => {
-    if (stats) {
-      console.log(`${configFilePath}已存在, 创建失败`)
+  const isExists = await fse.pathExists(configFilePath)
+  if (isExists) {
+    console.log(`${configFilePath}已存在, 创建失败`)
+  } else {
+    await fse.createFile(configFilePath)
+    const err = await fse.outputFile(configFilePath, fileTemplate)
+    if (err) {
+      console.log(`${configFilePath}创建失败 ${err}`)
     } else {
-      await fse.createFile(configFilePath)
-      const err = await fse.outputFile(configFilePath, fileTemplate)
-      if (err) {
-        console.log(`${configFilePath}创建失败 ${err}`)
-      } else {
-        console.log(`${configFilePath}创建成功`)
-        const stats = await fse.stat(gitignorePath)
-        if (stats) {
-          fse.appendFile(gitignorePath, ignoreAppendContent, err => {
-            if (err) {
-              console.log(`${gitignorePath}追加内容失败`)
-            } else {
-              console.log(`${gitignorePath}追加内容成功`)
-            }
-          })
-        }
+      console.log(`${configFilePath}创建成功`)
+      const stats = await fse.stat(gitignorePath)
+      if (stats) {
+        fse.appendFile(gitignorePath, ignoreAppendContent, err => {
+          if (err) {
+            console.log(`${gitignorePath}追加内容失败`)
+          } else {
+            console.log(`${gitignorePath}追加内容成功`)
+          }
+        })
       }
     }
-  })
+  }
+}
+
+const getRemoteTsConfig = async () => {
+  const workspaceConfigPath = resolveApp(configFilePath)
+  const isExists = await fse.pathExists(workspaceConfigPath)
+  if (isExists) {
+    let remoteTsConfig = await fse.readFile(workspaceConfigPath, 'utf8')
+    remoteTsConfig = await tsCompile(remoteTsConfig)
+    remoteTsConfig = requireFromString(remoteTsConfig.code, '')
+    console.log('## data', remoteTsConfig)
+    return remoteTsConfig
+  } else {
+    return null
+  }
 }
 
 /**
  * 同步远程文件
  */
 const pullTypes = async () => {
-  console.log('begin pullTypes')
-  const workspaceConfigPath = resolveApp(configFilePath)
-  console.log(`workspaceConfig: ${workspaceConfigPath} `)
-  fse.stat(workspaceConfigPath, async (err, stats) => {
-    if (stats) {
-      let remoteTsConfig = await fse.readFile(workspaceConfigPath, 'utf8')
-      remoteTsConfig = await tsCompile(remoteTsConfig)
-      remoteTsConfig = requireFromString(remoteTsConfig.code, '')
-      console.log('## data', remoteTsConfig)
-      console.log('## data', remoteTsConfig.default.pullConfig)
-      if (remoteTsConfig.default.pullConfig) {
-        for (let key in remoteTsConfig.default.pullConfig) {
-          if (
-            remoteTsConfig.default.pullConfig[key].indexOf('http://') > -1 ||
-            remoteTsConfig.default.pullConfig[key].indexOf('https://') > -1
-          ) {
-            downloadHttpFile(key, remoteTsConfig.default.pullConfig[key])
-          } else {
-            copyLocalFile(key, remoteTsConfig.default.pullConfig[key])
-          }
-        }
+  const remoteTsConfig = await getRemoteTsConfig()
+  if (remoteTsConfig.default.pullConfig && Object.keys(remoteTsConfig.default.pullConfig).length > 0) {
+    for (let key in remoteTsConfig.default.pullConfig) {
+      if (
+        remoteTsConfig.default.pullConfig[key].indexOf('http://') > -1 ||
+        remoteTsConfig.default.pullConfig[key].indexOf('https://') > -1
+      ) {
+        downloadHttpFile(key, remoteTsConfig.default.pullConfig[key])
+      } else {
+        copyLocalFile(key, remoteTsConfig.default.pullConfig[key])
       }
     }
-  })
+  } else {
+    console.log(`请使用 emp workspace:init 指令生成配置文件 并配置pullConfig`)
+  }
 }
 
 /**
@@ -117,6 +121,18 @@ const copyLocalFile = async (path, localUrl) => {
   })
 }
 
+/**
+ * 分发远程文件
+ * @param {*} type
+ */
+const pushTypes = async () => {
+  const remoteTsConfig = await getRemoteTsConfig()
+  console.log('remoteTsConfig.default.pushConfig.localPath', remoteTsConfig)
+  if (!remoteTsConfig.default.pushConfig || remoteTsConfig.default.pushConfig.localPath.length < 1) {
+    console.log('请使用 emp workspace:init 指令生成配置文件 并配置pushConfig')
+  }
+}
+
 module.exports = type => {
   switch (type) {
     case 'init':
@@ -124,6 +140,9 @@ module.exports = type => {
       break
     case 'pullTypes':
       pullTypes()
+      break
+    case 'pushTypes':
+      pushTypes()
       break
   }
 }

--- a/packages/emp-cli/scripts/workspace.js
+++ b/packages/emp-cli/scripts/workspace.js
@@ -1,0 +1,53 @@
+/**
+ * 生成本地开发配置
+ */
+const fs = require('fs')
+
+// todo 获取 emp.config 的配置，动态生成@fileTemplate内容
+// const {resolveApp} = require('../helpers/paths')
+// const package = require(`${resolveApp('package.json')}`)
+const configFilePath = `emp.workspace.config.ts`
+const gitignorePath = `.gitignore`
+const fileTemplate = `import {IWorkSpaceConfig} from '@efox/emp-cli/types/emp-workspace-config'
+
+const empWorkspaceConfig: IWorkSpaceConfig = {
+  pullConfig: {},
+  pushConfig: {
+    localPath: '',
+    remotePath: [],
+  },
+}
+export default empWorkspaceConfig
+`
+
+const ignoreAppendContent = `
+${configFilePath}
+types/
+`
+
+module.exports = () => {
+  fs.stat(configFilePath, (err, stats) => {
+    if (stats) {
+      console.log(`${configFilePath}已存在, 创建失败`)
+    } else {
+      fs.writeFile(configFilePath, fileTemplate, err => {
+        if (err) {
+          console.log(`${configFilePath}创建失败 ${err}`)
+        } else {
+          console.log(`${configFilePath}创建成功`)
+          fs.stat(gitignorePath, (err, stats) => {
+            if (stats) {
+              fs.appendFile(gitignorePath, ignoreAppendContent, err => {
+                if (err) {
+                  console.log(`${gitignorePath}追加内容失败`)
+                } else {
+                  console.log(`${gitignorePath}追加内容成功`)
+                }
+              })
+            }
+          })
+        }
+      })
+    }
+  })
+}

--- a/packages/emp-cli/scripts/workspace.js
+++ b/packages/emp-cli/scripts/workspace.js
@@ -96,7 +96,6 @@ const pullTypes = async () => {
  * @param {*} type
  */
 const downloadHttpFile = async (path, remoteUrl) => {
-  console.log('downloadHttpFile', path, remoteUrl)
   const file = fse.createWriteStream(`${resolveApp('types')}/${path}.d.ts`)
   const response = await axios({
     url: remoteUrl,

--- a/packages/emp-cli/types/emp-workspace-config.d.ts
+++ b/packages/emp-cli/types/emp-workspace-config.d.ts
@@ -1,0 +1,11 @@
+interface IWorkSpaceConfig {
+  /** @pullConfig获取远程声明文件配置 远程声明文件地址， 会自动同步到当前项目 types 目录 */
+  pullConfig: Record<string, string>
+  /** @pushConfig分发本地声明文件配置
+   * 生成声明文件后@localPath，
+   * 会自动分发到远程目录@remotePath */
+  pushConfig: {
+    localPath: Record<string, string>
+    remotePath: Array<string>
+  }
+}

--- a/packages/emp-cli/types/emp-workspace-config.d.ts
+++ b/packages/emp-cli/types/emp-workspace-config.d.ts
@@ -1,11 +1,12 @@
-interface IWorkSpaceConfig {
+import * as webpackChain from 'webpack-chain/types'
+declare interface IWorkSpaceConfig {
   /** @pullConfig获取远程声明文件配置 远程声明文件地址， 会自动同步到当前项目 types 目录 */
   pullConfig: Record<string, string>
   /** @pushConfig分发本地声明文件配置
    * 生成声明文件后@localPath，
    * 会自动分发到远程目录@remotePath */
   pushConfig: {
-    localPath: Record<string, string>
+    localPath: string
     remotePath: Array<string>
   }
 }

--- a/packages/emp-tune-dts-plugin/helpers/tuneType.js
+++ b/packages/emp-tune-dts-plugin/helpers/tuneType.js
@@ -12,7 +12,7 @@ function RepalceDts(fileData, regexp, replacement) {
 }
 
 // 默认替换
-function defaultRepalce(fileData) {
+function defaultRepalce(fileData, withVersion = false) {
   // 使用正则去掉结尾的 /index
   let newFileData = fileData.replace(/\/index'/g, "'")
   newFileData = newFileData.replace(/\/index"/g, '"')
@@ -22,6 +22,11 @@ function defaultRepalce(fileData) {
   const projectName = package.name
   newFileData = newFileData.replace(/'.*src?/g, `'${projectName}`)
   newFileData = newFileData.replace(/".*src?/g, `"${projectName}`)
+  if (withVersion) {
+    const replaceRegExp = new RegExp(projectName, 'g')
+    const versionMatch = package.version.match(/(\d+).(\d+).(\d+)/)
+    newFileData = newFileData.replace(replaceRegExp, `${package.name}v${versionMatch[1]}_${versionMatch[2]}`)
+  }
   return newFileData
 }
 
@@ -29,34 +34,13 @@ const emptyFunc = newFileData => {
   return newFileData
 }
 
-function tuneType(createPath, createName, isDefault, operation = emptyFunc) {
+function tuneType(createPath, createName, isDefault, operation = emptyFunc, withVersion = false) {
   // 获取 d.ts 文件
   const filePath = `${createPath}/${createName}`
   const fileData = fs.readFileSync(filePath, {encoding: 'utf-8'})
   let newFileData = ''
-
-  // 获取项目 tsconfig.json 路径
-  // const tsconfigPath = resolveApp('tsconfig.json')
-  // if (fs.existsSync(tsconfigPath)) {
-  //   const config = JSON.parse(fs.readFileSync(tsconfigPath))
-  //   const tuneType = config.tuneType
-
-  //   // 有tuneType则根据配置替换，无则默认替换
-  //   if (tuneType) {
-  //     newFileData = fileData
-  //     tuneType.map(item => {
-  //       console.log(item)
-  //       newFileData =
-  //         item.origin && item.replacement
-  //           ? RepalceDts(newFileData, item.origin, item.replacement)
-  //           : defaultRepalce(fileData)
-  //     })
-  //   } else {
-  //     newFileData = defaultRepalce(fileData)
-  //   }
-  // } else {
   newFileData = fileData
-  isDefault && (newFileData = defaultRepalce(fileData))
+  isDefault && (newFileData = defaultRepalce(fileData, withVersion))
   // }
   newFileData && (newFileData = operation(newFileData) ? operation(newFileData) : newFileData)
   // 覆盖原有 index.d.ts

--- a/packages/emp-tune-dts-plugin/index.d.ts
+++ b/packages/emp-tune-dts-plugin/index.d.ts
@@ -3,6 +3,7 @@ interface Options {
   path: string
   name: string
   isDefault: boolean
+  withVersion: boolean
 }
 
 export declare const tuneType: (

--- a/packages/emp-tune-dts-plugin/index.js
+++ b/packages/emp-tune-dts-plugin/index.js
@@ -11,7 +11,7 @@ const generateType = _options => {
   generator
     .generate()
     .then(() => {
-      tuneType(_options.path, _options.name, _options.isDefault, _options.operation)
+      tuneType(_options.path, _options.name, _options.isDefault, _options.operation, _options.withVersion)
     })
     .catch(function (e) {
       throw e

--- a/packages/emp-tune-dts-plugin/package.json
+++ b/packages/emp-tune-dts-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@efox/emp-tune-dts-plugin",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "keywords": [
     "react",
     "module federation",

--- a/projects/demo1/.gitignore
+++ b/projects/demo1/.gitignore
@@ -1,2 +1,6 @@
 dist
 node_module
+
+
+emp.workspace.config.ts
+types/

--- a/projects/demo1/.gitignore
+++ b/projects/demo1/.gitignore
@@ -4,3 +4,6 @@ node_module
 
 emp.workspace.config.ts
 types/
+
+emp.workspace.config.ts
+types/

--- a/projects/demo1/.gitignore
+++ b/projects/demo1/.gitignore
@@ -7,3 +7,6 @@ types/
 
 emp.workspace.config.ts
 types/
+
+emp.workspace.config.ts
+types/

--- a/projects/demo1/package.json
+++ b/projects/demo1/package.json
@@ -13,6 +13,7 @@
     "emp": "emp"
   },
   "dependencies": {
+    "@efox/emp-cli": "^1.8.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/projects/demo1/package.json
+++ b/projects/demo1/package.json
@@ -13,12 +13,11 @@
     "emp": "emp"
   },
   "dependencies": {
-    "@efox/emp-cli": "^1.8.4",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },
   "devDependencies": {
-    "@efox/emp-cli": "^1.4.0",
+    "@efox/emp-cli": "^1.8.4",
     "@efox/emp-tsconfig": "^1.0.0"
   }
 }


### PR DESCRIPTION
# 添加声明文件同步方案与声明文件多版本方案

## 前置条件:
+ 使用 `@efox/emp-cli` `1.8.6` 及以上版本
+ `tsconfig.json` `include`配置项请添加 `types` 目录
```json
"include": [
    "types"
]
```
+ `package.json`指令强化
```json
"dev": "emp workspace -t pullTypes && emp dev",
"tsc": "emp tsc -w && emp workspace -t pushTypes",
```
## 使用方式:
### 初始化本地emp工作区配置文件

命令行使用 `emp workspace -t init` 指令，会在当前工作目录根目录创建`emp.workspace.config.ts`配置文件，并会在当前目录 `.gitignore`添加`types/`与 `emp.workspace.config.ts`忽略，如项目已有上述文件，请重命名为其他文件，并在之前使用`git rm [filename]` 移除并`push`到远端

配置文件内容参考如下:
```javascript
import {IWorkSpaceConfig} from '@efox/emp-cli/types/emp-workspace-config'

const empWorkspaceConfig: IWorkSpaceConfig = {
    // 执行 emp workspace -t pullTypes 指令，会把 pullConfig配置的远程声明文件，拉到当前根目录 types目录下
  pullConfig: {
    pcbase: 'http://res-pc-bc-dev.rshun.net/emp_base/1.0.0/index.d.ts',
    chatbox: 'http://res-pc-bc.rshun.net/emp_chatbox/index.d.ts',
    stream: 'https://pcyy-base-component.yy.com/bdgamelive/streamer_1.0.10/index.d.ts',
    localTypeTest1: 'E:/baidu/git/bdgamelive/src/types/svga.d.ts',
    localTypeTest2: 'E:/baidu/git/bdgamelive/src/types/empbdgamechatbox.d.ts',
  },
  // 执行 emp workspace -t pushTypes 指令，会把 pushConfig配置的本地声明文件，推送到remotePath所在的目录
  pushConfig: {
    localPath: './dist/index.d.ts',
    remotePath: ['E:/baidu/git/test/zzz.d.ts', 'G:/baidu/git/test/zzz.d.ts'],
  },
}
export default empWorkspaceConfig
```

## 声明文件添加版本标识

使用`emp tsc -w`指令生成的声明文件，将会把`主要版本号`,`次要版本号`拼接到模块项目名中