### PR TITLE
feat: optimize compile

### DIFF
--- a/packages/emp-cli/webpack/config/development.js
+++ b/packages/emp-cli/webpack/config/development.js
@@ -7,7 +7,7 @@ module.exports = (args, config, env) => {
       usedExports: true,
     },
     // devtool: 'inline-source-map',
-    devtool: 'cheap-module-source-map',
+    devtool: 'eval-cheap-module-source-map',
     devServer,
   }
   config.merge(devConfig)

--- a/packages/emp-cli/webpack/config/plugin.js
+++ b/packages/emp-cli/webpack/config/plugin.js
@@ -43,25 +43,6 @@ module.exports = (env, config, {analyze, empEnv, ts, progress, createName, creat
           },
         ],
       },
-      clean: {plugin: CleanWebpackPlugin, args: []},
-      copy: {
-        plugin: CopyWebpackPlugin,
-        args: [
-          {
-            patterns: [
-              {
-                from: paths.public.replace(/\\/g, '/'),
-                to: paths.dist.replace(/\\/g, '/'),
-                globOptions: {
-                  // 加入 paths.template 避免被重置
-                  ignore: ['*.DS_Store', paths.template.replace(/\\/g, '/'), paths.favicon.replace(/\\/g, '/')],
-                },
-                noErrorOnMissing: true,
-              },
-            ],
-          },
-        ],
-      },
       html: {
         plugin: HtmlWebpackPlugin,
         args: [

--- a/packages/emp-cli/webpack/config/production.js
+++ b/packages/emp-cli/webpack/config/production.js
@@ -1,4 +1,9 @@
 const TerserPlugin = require('terser-webpack-plugin')
+const {CleanWebpackPlugin} = require('clean-webpack-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
+const {getPaths} = require('../../helpers/paths')
+const paths = getPaths()
+
 module.exports = (args, config, env) => {
   // const {devServer} = require('./devServer')(env, args)
   const prodConfig = {
@@ -10,6 +15,27 @@ module.exports = (args, config, env) => {
       hints: false,
       maxEntrypointSize: 512000,
       maxAssetSize: 512000,
+    },
+    plugin: {
+      clean: {plugin: CleanWebpackPlugin, args: []},
+      copy: {
+        plugin: CopyWebpackPlugin,
+        args: [
+          {
+            patterns: [
+              {
+                from: paths.public.replace(/\\/g, '/'),
+                to: paths.dist.replace(/\\/g, '/'),
+                globOptions: {
+                  // 加入 paths.template 避免被重置
+                  ignore: ['*.DS_Store', paths.template.replace(/\\/g, '/'), paths.favicon.replace(/\\/g, '/')],
+                },
+                noErrorOnMissing: true,
+              },
+            ],
+          },
+        ],
+      },
     },
   }
   config.merge(prodConfig)


### PR DESCRIPTION
1. 在实际项目中更新编译时，由于开发模式下使用了 CopyWebpackPlugin，造成如下问题：
   a. 所有 css 文件会重新编译一次，缓存无效；
   b. 保存项目内未被引用的文件会触发 webpack 更新编译；
   原因分析：https://github.com/webpack-contrib/copy-webpack-plugin/issues/504
   解决方案：移除开发模式下的 CopyWebpackPlugin 和 CleanWebpackPlugin，两者均无需在开发模式中使用。
2. devtool 改为官方推荐的 eval-cheap-module-source-map。
