### PR TITLE
fix: 修复emp-vue3中(ts|js)x报错问题

### DIFF
--- a/packages/emp-frameworks/vue3/index.js
+++ b/packages/emp-frameworks/vue3/index.js
@@ -35,6 +35,7 @@ module.exports = fn => ec => {
           // 支持 ts
           require.resolve('@babel/preset-typescript'),
           {
+            isTSX: true, // allExtensions依赖isTSX  https://babeljs.io/docs/en/babel-preset-typescript#allextensions
             allExtensions: true, // 支持所有文件扩展名
           },
         ],


### PR DESCRIPTION
`@efox/emp-vue3`包中babel-loader中的`@babel/preset-typescript`开启了`allExtensions`，需配合`isTSX`使用。
[https://babeljs.io/docs/en/babel-preset-typescript#allextensions](https://babeljs.io/docs/en/babel-preset-typescript#allextensions)