### PR TITLE
fix: cliOptions wplogger support filename

### DIFF
--- a/packages/emp/package.json
+++ b/packages/emp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@efox/emp",
-  "version": "2.0.8-beta.1",
+  "version": "2.0.8-beta.2",
   "description": "",
   "license": "MIT",
   "files": [

--- a/packages/emp/package.json
+++ b/packages/emp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@efox/emp",
-  "version": "2.0.8-beta.2",
+  "version": "2.0.8-beta.3",
   "description": "",
   "license": "MIT",
   "files": [

--- a/packages/emp/src/helper/store.ts
+++ b/packages/emp/src/helper/store.ts
@@ -102,7 +102,7 @@ class GlobalStore {
       await this.empShare.setup()
     }
     //show logger of config
-    if (this.config.debug.wplogger) logger.info('[emp-config]', this.config)
+    if (this.config.debug.wplogger === true) logger.info('[emp-config]', this.config)
   }
   private setAbsPaths() {
     //
@@ -119,6 +119,8 @@ class GlobalStore {
     if (cliOptions.clearLog === 'false' || cliOptions.clearLog === false) this.config.debug.clearLog = false
     if (cliOptions.profile === true) this.config.debug.profile = true
     if (cliOptions.wplogger === true) this.config.debug.wplogger = true
+    if (typeof cliOptions.wplogger === 'string' && cliOptions.wplogger.length > 0)
+      this.config.debug.wplogger = cliOptions.wplogger
     if (cliOptions.progress === 'false' || cliOptions.progress === false) this.config.debug.progress = false
     // server build 替换配置项
     if (cliOptions.open === true) this.config.server.open = true

--- a/packages/emp/src/types/index.ts
+++ b/packages/emp/src/types/index.ts
@@ -44,7 +44,7 @@ export type ConfigDebugType = {
   clearLog: boolean
   progress: boolean
   profile: boolean
-  wplogger: boolean
+  wplogger: boolean | string // --wplogger [filename] 可以为 string
   /**
    * 日志级别
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,31 +407,6 @@ importers:
       '@types/lodash': 4.14.177
       '@types/react-router-dom': 5.3.2
 
-  projects/e-svga:
-    specifiers:
-      '@efox/emp': '*'
-      '@types/offscreencanvas': ^2019.6.4
-      pbf: ^3.2.1
-      ttypescript: ^1.5.12
-      typescript: ^4.5.5
-      typescript-transform-paths: ^3.3.1
-    dependencies:
-      pbf: 3.2.1
-    devDependencies:
-      '@efox/emp': link:../../packages/emp
-      '@types/offscreencanvas': 2019.6.4
-      ttypescript: 1.5.12_typescript@4.6.2
-      typescript: 4.6.2
-      typescript-transform-paths: 3.3.1_typescript@4.6.2
-
-  projects/e-svga-demo:
-    specifiers:
-      '@efox/emp': workspace:*
-      '@friend/e-svga-emp': workspace:^1.4.5
-    dependencies:
-      '@efox/emp': link:../../packages/emp
-      '@friend/e-svga-emp': link:../e-svga
-
   projects/emp-lib:
     specifiers:
       '@efox/emp': workspace:*
@@ -11384,14 +11359,6 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  /pbf/3.2.1:
-    resolution: {integrity: sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==}
-    hasBin: true
-    dependencies:
-      ieee754: 1.2.1
-      resolve-protobuf-schema: 2.1.0
-    dev: false
-
   /performance-now/2.1.0:
     resolution: {integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=}
     dev: false
@@ -11992,10 +11959,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: false
-
-  /protocol-buffers-schema/3.6.0:
-    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
     dev: false
 
   /proxy-addr/2.0.7:
@@ -12952,12 +12915,6 @@ packages:
 
   /resolve-pathname/3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
-    dev: false
-
-  /resolve-protobuf-schema/2.1.0:
-    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
-    dependencies:
-      protocol-buffers-schema: 3.6.0
     dev: false
 
   /resolve-url/0.2.1:
@@ -14166,17 +14123,6 @@ packages:
       typescript: 4.5.2
     dev: true
 
-  /ttypescript/1.5.12_typescript@4.6.2:
-    resolution: {integrity: sha512-1ojRyJvpnmgN9kIHmUnQPlEV1gq+VVsxVYjk/NfvMlHSmYxjK5hEvOOU2MQASrbekTUiUM7pR/nXeCc8bzvMOQ==}
-    hasBin: true
-    peerDependencies:
-      ts-node: '>=8.0.2'
-      typescript: '>=3.2.2'
-    dependencies:
-      resolve: 1.22.0
-      typescript: 4.6.2
-    dev: true
-
   /type-check/0.3.2:
     resolution: {integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=}
     engines: {node: '>= 0.8.0'}
@@ -14317,15 +14263,6 @@ packages:
       typescript: 4.5.2
     dev: true
 
-  /typescript-transform-paths/3.3.1_typescript@4.6.2:
-    resolution: {integrity: sha512-c+8Cqd2rsRtTU68rJI0NX/OtqgBDddNs1fIxm1nCNyhn0WpoyqtpUxc1w9Ke5c5kgE4/OT5xYbKf2cf694RYEg==}
-    peerDependencies:
-      typescript: '>=3.6.5'
-    dependencies:
-      minimatch: 3.0.4
-      typescript: 4.6.2
-    dev: true
-
   /typescript/4.4.4:
     resolution: {integrity: sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==}
     engines: {node: '>=4.2.0'}
@@ -14333,12 +14270,6 @@ packages:
 
   /typescript/4.5.2:
     resolution: {integrity: sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
-  /typescript/4.6.2:
-    resolution: {integrity: sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/projects/emp-lib/package.json
+++ b/projects/emp-lib/package.json
@@ -24,7 +24,7 @@
   "private": true,
   "scripts": {
     "dev": "emp dev",
-    "build": "emp build",
+    "build": "emp build -wl config.js",
     "stat": "emp build --analyze",
 		"dts:build": "ttsc",
 		"dts": "ttsc -w"


### PR DESCRIPTION
修复:命令行传入'-wl, --wplogger [filename]'无法输出webpack配置到filename的问题。