### PR TITLE
优化图片资源打包逻辑

### DIFF
--- a/packages/emp/src/webpack/file.ts
+++ b/packages/emp/src/webpack/file.ts
@@ -32,7 +32,7 @@ class WPFile {
           },
           image: {
             test: /\.(png|jpe?g|gif|webp|ico)$/i,
-            type: 'asset',
+            type: 'asset/resource',
           },
           fonts: {
             test: /\.(|otf|ttf|eot|woff|woff2)$/i,

--- a/packages/emp/src/webpack/production.ts
+++ b/packages/emp/src/webpack/production.ts
@@ -12,7 +12,7 @@ class WPProduction {
       mode: 'production',
       devtool: store.config.build.sourcemap ? 'source-map' : false, //Recommended
       performance: {
-        hints: false,
+        hints: 'warning',
         maxEntrypointSize: 512000,
         maxAssetSize: 512000,
       },


### PR DESCRIPTION
1. 大量小图片inline到css中导致单个css文件大小暴增，且没有给出性能提示，所以建议加上。
2. 修改媒体资源打包逻辑，图片等资源默认不inline到css中
