### PR TITLE
feat: 增加dts可配置项

### DIFF
--- a/offical/config/dts.md
+++ b/offical/config/dts.md
@@ -1,40 +1,56 @@
 # Dts 生成与同步
+
 ## build.typesOutDir
-+ 类型 `string`
-+ 默认 `dist/empShareTypes`
+
+- 类型 `string`
+- 默认 `dist/empShareTypes`
 
 当前项目声明文件输出目录
 
 ## build.typesEmpName
-+ 类型 `string`
-+ 默认 `index.d.ts` 生成 与 同步相同
 
-生成EMP基站类型文件 默认为 `index.d.ts`
+- 类型 `string`
+- 默认 `index.d.ts` 生成 与 同步相同
+
+生成 EMP 基站类型文件 默认为 `index.d.ts`
+
 ## build.typesLibName
-+ 类型 `string`
-+ 默认 `lib.d.ts`
 
-生成库 类型文件 默认为 `lib.d.ts` 可以在package.json types 设置 `./dist/lib.d.ts`
+- 类型 `string`
+- 默认 `lib.d.ts`
+
+生成库 类型文件 默认为 `lib.d.ts` 可以在 package.json types 设置 `./dist/lib.d.ts`
 
 ## build.createTs
-+ 类型 `boolean`
-+ 默认 `false`
+
+- 类型 `boolean`
+- 默认 `false`
 
 是否生成 d.ts
 
 ## build.jsToJsx
-+ 类型 `boolean`
-+ 默认 `false`
+
+- 类型 `boolean`
+- 默认 `false`
 
 是否支持在 js 中使用 jsx
 
 ## dtsPath
-+ 类型 `{[key: string]: string}`
-+ 默认 `<remoteHost>/empShareTypes/index.d.ts`
-+ 配置例子:
+
+- 类型 `{[key: string]: string}`
+- 默认 `<remoteHost>/empShareTypes/index.d.ts`
+- 配置例子:
+
 ```js
    dtsPath: {
     //  '对应 remotes 里的项目名' : '.dts 文件的远程路径'
       '@microHost': 'http://127.0.0.1:8001/types/index.d.ts',
     },
 ```
+
+## build.dtsRemoveSrcPrefix
+
+- 类型 `boolean`
+- 默认 `true`
+
+dts 时，映射 `appSrc`路径到根路径

--- a/packages/emp/src/config/build.ts
+++ b/packages/emp/src/config/build.ts
@@ -93,6 +93,11 @@ export type BuildOptions = {
    * @default false
    */
   jsToJsx?: boolean
+  /**
+   * dts时映射appSrc到根目录
+   * @default true
+   */
+  dtsRemoveSrcPrefix?: boolean
 }
 export type RquireBuildOptions = Override<
   Required<BuildOptions>,
@@ -128,6 +133,7 @@ export const initBuild = (op?: BuildOptions): RquireBuildOptions => {
       analyze: false,
       createTs: false,
       jsToJsx: false,
+      dtsRemoveSrcPrefix: true,
     },
     ...op,
   }

--- a/packages/emp/src/webpack/plugin/dts/transform.ts
+++ b/packages/emp/src/webpack/plugin/dts/transform.ts
@@ -14,7 +14,7 @@ export const transformLibName = (name: string, code: string) => {
   code = code.replace(`declare module '${store.config.appSrc}'`, `declare module '${name}'`)
   // 兼容 不支持 replace all 的情况
   const reg = new RegExp(`${store.config.appSrc}/`, 'g')
-  return code.replace(reg, `${name}/`)
+  return code.replace(reg, store.config.build.dtsRemoveSrcPrefix ? `${name}/` : `${name}/${store.config.appSrc}/`)
   // return code.replaceAll(`${store.config.appSrc}/`, `${name}/`)
 }
 export const transformPathImport = (o: ts.OutputFile) => {


### PR DESCRIPTION
原来dts默认行为：dts内容的 `declare module` 默认去掉src路径

本次修改：
增加可配置项，保留src路径（用于物料库规范构建规范）